### PR TITLE
Update flashlight text decoder extension for TorchAudio adoptation

### DIFF
--- a/bindings/python/flashlight/lib/text/_decoder.cpp
+++ b/bindings/python/flashlight/lib/text/_decoder.cpp
@@ -14,6 +14,7 @@
 #if FL_TEXT_USE_KENLM
 #include "flashlight/lib/text/decoder/lm/KenLM.h"
 #endif // FL_TEXT_USE_KENLM
+#include "flashlight/lib/text/decoder/lm/ZeroLM.h"
 
 namespace py = pybind11;
 using namespace fl::lib::text;
@@ -170,6 +171,8 @@ PYBIND11_MODULE(flashlight_lib_text_decoder, m) {
           "path"_a,
           "usr_token_dict"_a);
 #endif
+
+  py::class_<ZeroLM, ZeroLMPtr, LM>(m, "ZeroLM").def(py::init<>());
 
   py::enum_<CriterionType>(m, "CriterionType")
       .value("ASG", CriterionType::ASG)

--- a/flashlight/lib/text/decoder/lm/ZeroLM.h
+++ b/flashlight/lib/text/decoder/lm/ZeroLM.h
@@ -27,6 +27,8 @@ class ZeroLM : public LM {
 
   std::pair<LMStatePtr, float> finish(const LMStatePtr& state) override;
 };
+
+using ZeroLMPtr = std::shared_ptr<ZeroLM>;
 } // namespace text
 } // namespace lib
 } // namespace fl


### PR DESCRIPTION
Summary:
Make changes to fill some gaps for adopting FL Text decoder in TorchAudio.

1. Make the extension module `flashlight_lib_text_decoder` expose KenLM and ZeroLM.
2. Add `ZeroLMPtr` alias in `ZeroLM.h`.

Differential Revision: D37983766

