### PR TITLE
Add ZeroLM to python bindings

### DIFF
--- a/bindings/python/flashlight/lib/text/decoder.py
+++ b/bindings/python/flashlight/lib/text/decoder.py
@@ -20,6 +20,7 @@ from .flashlight_lib_text_decoder import (
     SmearingMode,
     Trie,
     TrieNode,
+    ZeroLM,
 )
 
 try:


### PR DESCRIPTION
#8 added ZeroLM pybind, but did not include import it into the Python file
