### PR TITLE
Include <string> in Trie.cpp

### DIFF
--- a/flashlight/lib/text/decoder/Trie.cpp
+++ b/flashlight/lib/text/decoder/Trie.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <iostream>
 #include <limits>
+#include <string>
 
 #include "flashlight/lib/text/decoder/Trie.h"
 


### PR DESCRIPTION
Summary:
`std::to_string` is defined in `<string>` header.
https://en.cppreference.com/w/cpp/string/basic_string/to_string

`gcc` and `clang` are fine without the header, but `cl.exe` is not.

```
C:\...\flashlight\lib\text\decoder\Trie.cpp(32): error C2039: 'to_string': is not a member of 'std'
C:\...\flashlight\lib\text\decoder\Trie.cpp(32): error C3861: 'to_string': identifier not found
C:\...\flashlight\lib\text\decoder\Trie.cpp(31): error C2512: 'std::out_of_range': no appropriate default constructor available
C:\...\flashlight\lib\text\decoder\Trie.cpp(32): note: No constructor could take the source type, or constructor overload resolution was ambiguous
C:\...\flashlight\lib\text\decoder\Trie.cpp(54): error C2039: 'to_string': is not a member of 'std'
C:\...\flashlight\lib\text\decoder\Trie.cpp(54): error C3861: 'to_string': identifier not found
C:\...\flashlight\lib\text\decoder\Trie.cpp(53): error C2512: 'std::out_of_range': no appropriate default constructor available
C:\...\flashlight\lib\text\decoder\Trie.cpp(54): note: No constructor could take the source type, or constructor overload resolution was ambiguous
```

Differential Revision: D38194039

