### PR TITLE
Bump gtest to 1.12.1

### DIFF
--- a/cmake/BuildGoogleTest.cmake
+++ b/cmake/BuildGoogleTest.cmake
@@ -5,7 +5,7 @@ include(ExternalProject)
 set(gtest_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googletest/include)
 set(gtest_URL https://github.com/google/googletest.git)
 set(gtest_BUILD ${CMAKE_CURRENT_BINARY_DIR}/third-party/googletest)
-set(gtest_TAG release-1.11.0)
+set(gtest_TAG release-1.12.1)
 set(gtest_BINARY_DIR ${gtest_BUILD}/src/gtest-build)
 
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
Update gtest to 1.12.1 — fixes build issues on some macOS LLVM versions.

Test plan: CI

### Checklist

- [x] Test coverage
- [X] Tests pass
- [X] Code formatted
- [X] Rebased on latest matter
- [X] Code documented
