### PR TITLE
[build] Use FetchContent to get gtest

### DIFF
--- a/cmake/BuildGoogleTest.cmake
+++ b/cmake/BuildGoogleTest.cmake
@@ -1,82 +1,15 @@
-cmake_minimum_required(VERSION 3.10.0)
+cmake_minimum_required(VERSION 3.14)
 
-include(ExternalProject)
+include(FetchContent)
 
-set(gtest_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googletest/include)
 set(gtest_URL https://github.com/google/googletest.git)
-set(gtest_BUILD ${CMAKE_CURRENT_BINARY_DIR}/third-party/googletest)
 set(gtest_TAG release-1.12.1)
-set(gtest_BINARY_DIR ${gtest_BUILD}/src/gtest-build)
 
-if (BUILD_SHARED_LIBS)
-  set(LIB_TYPE SHARED)
-else()
-  set(LIB_TYPE STATIC)
-endif()
-
-# Built asset paths
-set(GTEST_LIBRARIES
-  "${gtest_BINARY_DIR}/lib/${CMAKE_${LIB_TYPE}_LIBRARY_PREFIX}gtest${CMAKE_${LIB_TYPE}_LIBRARY_SUFFIX}"
-)
-set(GTEST_LIBRARIES_MAIN
-  "${gtest_BINARY_DIR}/lib/${CMAKE_${LIB_TYPE}_LIBRARY_PREFIX}gtest_main${CMAKE_${LIB_TYPE}_LIBRARY_SUFFIX}"
-)
-set(GMOCK_LIBRARIES
-  "${gtest_BINARY_DIR}/lib/${CMAKE_${LIB_TYPE}_LIBRARY_PREFIX}gmock${CMAKE_${LIB_TYPE}_LIBRARY_SUFFIX}"
-)
-set(GMOCK_LIBRARIES_MAIN
-  "${gtest_BINARY_DIR}/lib/${CMAKE_${LIB_TYPE}_LIBRARY_PREFIX}gmock_main${CMAKE_${LIB_TYPE}_LIBRARY_SUFFIX}"
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY ${gtest_URL}
+  GIT_TAG        ${gtest_TAG}
 )
 
-if (NOT TARGET gtest)
-  # Download googletest
-  ExternalProject_Add(
-    gtest
-    PREFIX ${gtest_BUILD}
-    GIT_REPOSITORY ${gtest_URL}
-    GIT_TAG ${gtest_TAG}
-    INSTALL_COMMAND ""
-    BUILD_BYPRODUCTS
-      ${GTEST_LIBRARIES}
-      ${GTEST_LIBRARIES_MAIN}
-      ${GMOCK_LIBRARIES}
-      ${GMOCK_LIBRARIES_MAIN}
-    CMAKE_CACHE_ARGS
-      -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
-      -DCMAKE_BUILD_TYPE:STRING=Release
-      -DBUILD_GMOCK:BOOL=ON
-      -DBUILD_GTEST:BOOL=ON
-      -Dgtest_force_shared_crt:BOOL=OFF
-  )
-endif ()
-
-ExternalProject_Get_Property(gtest source_dir)
-set(GTEST_SOURCE_DIR ${source_dir})
-
-set(GTEST_INCLUDE_DIRS ${GTEST_SOURCE_DIR}/googletest/include)
-set(GMOCK_INCLUDE_DIRS ${GTEST_SOURCE_DIR}/googlemock/include)
-# Make dirs so this can be used as an interface include directory
-file(MAKE_DIRECTORY ${GTEST_INCLUDE_DIRS})
-file(MAKE_DIRECTORY ${GMOCK_INCLUDE_DIRS})
-
-add_library(GTest::gtest ${LIB_TYPE} IMPORTED)
-add_library(GTest::gtest_main ${LIB_TYPE} IMPORTED)
-add_library(GTest::gmock ${LIB_TYPE} IMPORTED)
-add_library(GTest::gmock_main ${LIB_TYPE} IMPORTED)
-
-set_target_properties(GTest::gtest PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES ${GTEST_INCLUDE_DIRS}
-  IMPORTED_LOCATION ${GTEST_LIBRARIES}
-  )
-set_target_properties(GTest::gtest_main PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES ${GTEST_INCLUDE_DIRS}
-  IMPORTED_LOCATION ${GTEST_LIBRARIES_MAIN}
-  )
-set_target_properties(GTest::gmock PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES ${GMOCK_INCLUDE_DIRS}
-  IMPORTED_LOCATION ${GMOCK_LIBRARIES}
-  )
-set_target_properties(GTest::gmock_main PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES ${GMOCK_INCLUDE_DIRS}
-  IMPORTED_LOCATION ${GMOCK_LIBRARIES_MAIN}
-  )
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE) # for Windows
+FetchContent_MakeAvailable(googletest)

--- a/cmake/TestUtils.cmake
+++ b/cmake/TestUtils.cmake
@@ -1,15 +1,15 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 
-set(GTEST_IMPORTED_TARGETS "")
+set(GTEST_TARGETS "")
 
 # Get or find Google Test and Google Mock
-find_package(GTest 1.10.0)
+find_package(GTest 1.12.1)
 if (NOT GTEST_FOUND)
   if (NOT TARGET gtest)
     message(STATUS "googletest not found - will download and build from source")
-    # Download and build googletest
-    include(${CMAKE_MODULE_PATH}/BuildGoogleTest.cmake) # internally sets GTEST_LIBRARIES
-    list(APPEND GTEST_IMPORTED_TARGETS GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
+    # Download, build, and find the resulting googletest
+    include(${CMAKE_MODULE_PATH}/BuildGoogleTest.cmake)
+    list(APPEND GTEST_TARGETS GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
   endif()
 else()
   message(STATUS "gtest found: (include: ${GTEST_INCLUDE_DIRS}, lib: ${GTEST_BOTH_LIBRARIES}")
@@ -18,13 +18,14 @@ else()
     if (NOT TARGET GTest::Main)
       message(FATAL_ERROR "Google Test must be built with main")
     endif()
-    list(APPEND GTEST_IMPORTED_TARGETS GTest::GTest GTest::Main)
+    # TODO: these targets are deprecated in CMake 3.20
+    list(APPEND GTEST_TARGETS GTest::GTest GTest::Main)
   endif()
   if (NOT TARGET GTest::gmock)
     find_package(GMock REQUIRED)
     message(STATUS "gmock found: (include: ${GMOCK_INCLUDE_DIRS}, lib: ${GMOCK_BOTH_LIBRARIES})")
   endif()
-  list(APPEND GTEST_IMPORTED_TARGETS GTest::gmock GTest::gmock_main)
+  list(APPEND GTEST_TARGETS GTest::gmock GTest::gmock_main)
   message(STATUS "Found gtest and gmock on system.")
 endif()
 
@@ -47,7 +48,7 @@ function(build_test)
   target_link_libraries(
     ${target}
     PUBLIC
-    ${GTEST_IMPORTED_TARGETS}
+    ${GTEST_TARGETS}
     ${build_test_LIBS}
      ${CMAKE_THREAD_LIBS_INIT}
     )


### PR DESCRIPTION
Use FetchContent to download and build gtest. This requires a bump to CMake 3.14 minimum, but it's worth the cross platform and build speedups. Ubuntu 20.04 ships with CMake 3.16, so support's there. May augment this PR to enforce CMake 3.14 project-wide

Test plan: CI

### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest master
- [x] Code documented
