### PR TITLE
[build] Fix MSVC build

### DIFF
--- a/flashlight/lib/text/test/dictionary/DictionaryTest.cpp
+++ b/flashlight/lib/text/test/dictionary/DictionaryTest.cpp
@@ -45,7 +45,7 @@ TEST(DictionaryTest, TestBasic) {
 TEST(DictionaryTest, FromFile) {
   ASSERT_THROW(Dictionary("not_a_real_file"), std::runtime_error);
 
-  Dictionary dict(loadPath / "test.dict");
+  Dictionary dict((loadPath / "test.dict").string());
   ASSERT_EQ(dict.entrySize(), 10);
   ASSERT_EQ(dict.indexSize(), 7);
   ASSERT_TRUE(dict.contains("a"));

--- a/flashlight/lib/text/test/tokenizer/TokenizerTest.cpp
+++ b/flashlight/lib/text/test/tokenizer/TokenizerTest.cpp
@@ -21,8 +21,8 @@ TEST(PartialFileReaderTest, Reading) {
   fl::lib::text::PartialFileReader subFile1(0, 2);
   fl::lib::text::PartialFileReader subFile2(1, 2);
 
-  subFile1.loadFile(loadPath / "test.txt");
-  subFile2.loadFile(loadPath / "test.txt");
+  subFile1.loadFile((loadPath / "test.txt").string());
+  subFile2.loadFile((loadPath / "test.txt").string());
 
   std::vector<std::string> target = {
       "this",
@@ -59,7 +59,7 @@ TEST(PartialFileReaderTest, Reading) {
 
 TEST(TokenizerTest, Counting) {
   auto tokenizer = fl::lib::text::Tokenizer();
-  tokenizer.countTokens(loadPath / "test.txt", 2);
+  tokenizer.countTokens((loadPath / "test.txt").string(), 2);
   ASSERT_EQ(tokenizer.totalTokens(), 13);
   ASSERT_EQ(tokenizer.totalSentences(), 4);
 


### PR DESCRIPTION
Fix MSVC nitpicks with `std::filesystem::path` implicit casting to `std::string`

Test plan: local build on MSVC + CI baseline test

### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest master
- [x] Code documented
