### PR TITLE
Add Python build to MSVC CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,10 @@ commands:
           name: "Install Build Dependencies"
           command: |
             choco install cmake python3 -y
+      # windows needs a path modification
+      - run:
+          name: "Set PATH to find CMake"
+          command: echo 'export PATH="$PATH:/c/Program Files/CMake/bin"' >> $BASH_ENV
   install_kenlm:
     parameters:
       platform:
@@ -78,14 +82,6 @@ commands:
         type: string
         default: "linux"
     steps:
-      # windows needs a path modification
-      - when:
-          condition:
-            equal: ["windows", << parameters.platform >>]
-          steps:
-            - run:
-                name: "Set PATH to find CMake"
-                command: echo 'export PATH="$PATH:/c/Program Files/CMake/bin"' >> $BASH_ENV
       - run:
           name: "Build and Install Flashlight Text"
           command: |
@@ -336,6 +332,20 @@ jobs:
           platform: "windows"
           use_kenlm: "OFF"
 
+  windows_msvc_python:
+    parameters:
+      use_kenlm:
+        type: string
+        default: "OFF"
+    executor:
+      name: win/default
+      shell: bash.exe
+    steps:
+      - checkout
+      - install_msvc_build_dependencies
+      - install_python_bindings:
+          use_kenlm: "OFF"
+
 workflows:
   build-test:
     jobs:
@@ -375,3 +385,5 @@ workflows:
           use_kenlm: "ON"
       - windows_msvc:
           name: "Windows VS 17 2022 | MSVC 19.33 no-standalone"
+      - windows_msvc_python:
+          name: "Windows VS 17 2022 | MSVC 19.33 Python"

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -73,15 +73,14 @@ class CMakeBuild(build_ext):
         build_args = ["--config", cfg]
 
         if platform.system() == "Windows":
-            # cmake_args += [
-            #     "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), ext_dir)
-            # ]
-            # if sys.maxsize > 2 ** 32:
-            #     cmake_args += ["-A", "x64"]
-            # build_args += ["--", "/m"]
-            raise RuntimeError(
-                "flashlight-text doesn't support building on Windows [yet]"
-            )
+            cmake_args += [
+                "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON",
+                "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), ext_dir),
+                "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), ext_dir),
+            ]
+            if sys.maxsize > 2**32:
+                cmake_args += ["-A", "x64"]
+            build_args += ["--", "/m"]
         else:
             cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
             build_args += ["--", "-j4"]


### PR DESCRIPTION
### Summary
See title. Fixed by adding `-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON` to the Windows build which actually exported everything without having to change the source, hooray

Enables building Flashlight Text wheels on Windows

Test plan: CI
