### PR TITLE
Update pybind to v2.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,11 @@ commands:
           condition:
             equal: ["ON", << parameters.use_kenlm >>]
           steps:
-            - run: |
-                sudo apt -y install libboost-program-options-dev libboost-system-dev libboost-thread-dev \
-                libboost-test-dev liblzma-dev libbz2-dev zlib1g-dev
+            - run:
+                name: "Install KenLM Build Dependencies"
+                command: |
+                  sudo apt -y install libboost-program-options-dev libboost-system-dev libboost-thread-dev \
+                  libboost-test-dev liblzma-dev libbz2-dev zlib1g-dev
   install_macos_build_dependencies:
     steps:
       - run:

--- a/cmake/Buildpybind11.cmake
+++ b/cmake/Buildpybind11.cmake
@@ -1,7 +1,7 @@
 include(ExternalProject)
 
 set(pybind11_URL https://github.com/pybind/pybind11.git)
-set(pybind11_TAG 9a19306fbf30642ca331d0ec88e7da54a96860f9) # release 2.2.4
+set(pybind11_TAG v2.10.0)
 
 # Download pybind11
 ExternalProject_Add(


### PR DESCRIPTION
### Summary
Ensures compatibility with Python 3.11rc's and ostensibly improves performance.

The PyTorch core is also sitting at 2.10.0, so this brings things in sync.

### Test Plan: CI
