### PR TITLE
Rename rename acoustic-model-specific callbacks

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -139,7 +139,7 @@ Finally, we can run lexicon-based decoder:
     transitions = numpy.zeros((token_dict.index_size(), token_dict.index_size()) # for ASG fill up with correct values
     is_token_lm = False # we use word-level LM
     decoder = LexiconDecoder(options, trie, lm, sil_idx, blank_idx, unk_idx, transitions, is_token_lm)
-    # emissions is numpy.array of acoustic model predictions with shape [T, N], where T is time, N is number of tokens
+    # emissions is numpy.array of emitting model predictions with shape [T, N], where T is time, N is number of tokens
     results = decoder.decode(emissions.ctypes.data, T, N)
     # results[i].tokens contains tokens sequence (with length T)
     # results[i].score contains score of the hypothesis

--- a/bindings/python/flashlight/lib/text/_decoder.cpp
+++ b/bindings/python/flashlight/lib/text/_decoder.cpp
@@ -240,7 +240,7 @@ PYBIND11_MODULE(flashlight_lib_text_decoder, m) {
   py::class_<DecodeResult>(m, "DecodeResult")
       .def(py::init<int>(), "length"_a)
       .def_readwrite("score", &DecodeResult::score)
-      .def_readwrite("amScore", &DecodeResult::amScore)
+      .def_readwrite("emittingModelScore", &DecodeResult::emittingModelScore)
       .def_readwrite("lmScore", &DecodeResult::lmScore)
       .def_readwrite("words", &DecodeResult::words)
       .def_readwrite("tokens", &DecodeResult::tokens);

--- a/bindings/python/test/test_decoder.py
+++ b/bindings/python/test/test_decoder.py
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 """
 
 # Perform beam-search decoding with word-level LM
-# this is test with dumped acoustic model scores
+# this is test with dumped emitting model scores
 
 import math
 import os
@@ -104,7 +104,7 @@ class DecoderTestCase(unittest.TestCase):
         print(f"Running {__class__} with DATA_DIR={data_path}")
 
         # load test files
-        # load time and number of tokens for dumped acoustic scores
+        # load time and number of tokens for dumped emitting model scores
         T, N = load_tn(os.path.join(data_path, "TN.bin"))
         # load emissions [Batch=1, Time, Ntokens]
         emissions = load_emissions(os.path.join(data_path, "emission.bin"), T, N)
@@ -119,7 +119,7 @@ class DecoderTestCase(unittest.TestCase):
         word_dict = create_word_dict(lexicon)
         # create w2l dict with tokens set (letters in this example)
         token_dict = Dictionary(os.path.join(data_path, "letters.lst"))
-        # add repetition symbol as soon as we have ASG acoustic model
+        # add repetition symbol as soon as we have ASG emitting model
         token_dict.add_entry("<1>")
         # create Kenlm language model
         lm = KenLM(os.path.join(data_path, "lm.arpa"), word_dict)
@@ -216,7 +216,7 @@ class DecoderTestCase(unittest.TestCase):
                 prediction.append(token_dict.get_entry(idx))
             prediction = " ".join(prediction)
             print(
-                f"score={results[i].score} amScore={results[i].amScore} lmScore={results[i].lmScore} prediction='{prediction}'"
+                f"score={results[i].score} emittingModelScore={results[i].emittingModelScore} lmScore={results[i].lmScore} prediction='{prediction}'"
             )
 
         self.assertEqual(len(results), 16)

--- a/flashlight/lib/text/decoder/LexiconDecoder.cpp
+++ b/flashlight/lib/text/decoder/LexiconDecoder.cpp
@@ -66,12 +66,12 @@ void LexiconDecoder::decodeStep(const float* emissions, int T, int N) {
           continue;
         }
         const TrieNodePtr& lex = iter->second;
-        double amScore = emissions[t * N + n];
+        double emittingModelScore = emissions[t * N + n];
         if (nDecodedFrames_ + t > 0 &&
             opt_.criterionType == CriterionType::ASG) {
-          amScore += transitions_[n * N + prevIdx];
+          emittingModelScore += transitions_[n * N + prevIdx];
         }
-        double score = prevHyp.score + amScore;
+        double score = prevHyp.score + emittingModelScore;
         if (n == sil_) {
           score += opt_.silScore;
         }
@@ -104,7 +104,7 @@ void LexiconDecoder::decodeStep(const float* emissions, int T, int N) {
                 n,
                 -1,
                 false, // prevBlank
-                prevHyp.amScore + amScore,
+                prevHyp.emittingModelScore + emittingModelScore,
                 prevHyp.lmScore + lmScore);
           }
         }
@@ -137,7 +137,7 @@ void LexiconDecoder::decodeStep(const float* emissions, int T, int N) {
               n,
               label,
               false, // prevBlank
-              prevHyp.amScore + amScore,
+              prevHyp.emittingModelScore + emittingModelScore,
               prevHyp.lmScore + lmScore);
         }
 
@@ -159,7 +159,7 @@ void LexiconDecoder::decodeStep(const float* emissions, int T, int N) {
               n,
               unk_,
               false, // prevBlank
-              prevHyp.amScore + amScore,
+              prevHyp.emittingModelScore + emittingModelScore,
               prevHyp.lmScore + lmScore);
         }
       }
@@ -168,12 +168,12 @@ void LexiconDecoder::decodeStep(const float* emissions, int T, int N) {
       if (opt_.criterionType != CriterionType::CTC || !prevHyp.prevBlank ||
           prevLex == lexicon_->getRoot()) {
         int n = prevLex == lexicon_->getRoot() ? sil_ : prevIdx;
-        double amScore = emissions[t * N + n];
+        double emittingModelScore = emissions[t * N + n];
         if (nDecodedFrames_ + t > 0 &&
             opt_.criterionType == CriterionType::ASG) {
-          amScore += transitions_[n * N + prevIdx];
+          emittingModelScore += transitions_[n * N + prevIdx];
         }
-        double score = prevHyp.score + amScore;
+        double score = prevHyp.score + emittingModelScore;
         if (n == sil_) {
           score += opt_.silScore;
         }
@@ -189,26 +189,26 @@ void LexiconDecoder::decodeStep(const float* emissions, int T, int N) {
             n,
             -1,
             false, // prevBlank
-            prevHyp.amScore + amScore,
+            prevHyp.emittingModelScore + emittingModelScore,
             prevHyp.lmScore);
       }
 
       /* (3) CTC only, try blank */
       if (opt_.criterionType == CriterionType::CTC) {
         int n = blank_;
-        double amScore = emissions[t * N + n];
+        double emittingModelScore = emissions[t * N + n];
         candidatesAdd(
             candidates_,
             candidatesBestScore_,
             opt_.beamThreshold,
-            prevHyp.score + amScore,
+            prevHyp.score + emittingModelScore,
             prevHyp.lmState,
             prevLex,
             &prevHyp,
             n,
             -1,
             true, // prevBlank
-            prevHyp.amScore + amScore,
+            prevHyp.emittingModelScore + emittingModelScore,
             prevHyp.lmScore);
       }
       // finish proposing
@@ -257,7 +257,7 @@ void LexiconDecoder::decodeEnd() {
           sil_,
           -1,
           false, // prevBlank
-          prevHyp.amScore,
+          prevHyp.emittingModelScore,
           prevHyp.lmScore + lmScore);
     }
   }

--- a/flashlight/lib/text/decoder/LexiconDecoder.h
+++ b/flashlight/lib/text/decoder/LexiconDecoder.h
@@ -41,7 +41,7 @@ struct LexiconDecoderState {
   int word; // Label of word (-1 if incomplete)
   bool prevBlank; // If previous hypothesis is blank (for CTC only)
 
-  double amScore; // Accumulated AM score so far
+  double emittingModelScore; // Accumulated AM score so far
   double lmScore; // Accumulated LM score so far
 
   LexiconDecoderState(
@@ -52,7 +52,7 @@ struct LexiconDecoderState {
       const int token,
       const int word,
       const bool prevBlank = false,
-      const double amScore = 0,
+      const double emittingModelScore = 0,
       const double lmScore = 0)
       : score(score),
         lmState(lmState),
@@ -61,7 +61,7 @@ struct LexiconDecoderState {
         token(token),
         word(word),
         prevBlank(prevBlank),
-        amScore(amScore),
+        emittingModelScore(emittingModelScore),
         lmScore(lmScore) {}
 
   LexiconDecoderState()
@@ -72,7 +72,7 @@ struct LexiconDecoderState {
         token(-1),
         word(-1),
         prevBlank(false),
-        amScore(0.),
+        emittingModelScore(0.),
         lmScore(0.) {}
 
   int compareNoScoreStates(const LexiconDecoderState* node) const {
@@ -106,7 +106,7 @@ struct LexiconDecoderState {
  * |W_unknown| + silScore_ * |{i| pi_i = <sil>}|
  *
  * where P_{lm}(W) is the language model score, pi_i is the value for the i-th
- * frame in the path leading to W and AM(W) is the (unnormalized) acoustic model
+ * frame in the path leading to W and AM(W) is the (unnormalized) emitting model
  * score of the transcription W. Note that the lexicon is used to limit the
  * search space and all candidate words are generated from it if unkScore is
  * -inf, otherwise <UNK> will be generated for OOVs.
@@ -160,7 +160,7 @@ class LexiconDecoder : public Decoder {
   int unk_;
   // matrix of transitions (for ASG criterion)
   std::vector<float> transitions_;
-  // if LM is token-level (operates on the same level as acoustic model)
+  // if LM is token-level (operates on the same level as the emitting model)
   // or it is word-level (in case of false)
   bool isLmToken_;
 

--- a/flashlight/lib/text/decoder/LexiconFreeDecoder.cpp
+++ b/flashlight/lib/text/decoder/LexiconFreeDecoder.cpp
@@ -56,10 +56,10 @@ void LexiconFreeDecoder::decodeStep(const float* emissions, int T, int N) {
 
       for (int r = 0; r < std::min(opt_.beamSizeToken, N); ++r) {
         int n = idx[r];
-        double amScore = emissions[t * N + n];
+        double emittingModelScore = emissions[t * N + n];
         if (nDecodedFrames_ + t > 0 &&
             opt_.criterionType == CriterionType::ASG) {
-          amScore += transitions_[n * N + prevIdx];
+          emittingModelScore += transitions_[n * N + prevIdx];
         }
         double score = prevHyp.score + emissions[t * N + n];
         if (n == sil_) {
@@ -81,7 +81,7 @@ void LexiconFreeDecoder::decodeStep(const float* emissions, int T, int N) {
               &prevHyp,
               n,
               false, // prevBlank
-              prevHyp.amScore + amScore,
+              prevHyp.emittingModelScore + emittingModelScore,
               prevHyp.lmScore + lmScore);
         } else if (opt_.criterionType == CriterionType::CTC && n == blank_) {
           candidatesAdd(
@@ -93,7 +93,7 @@ void LexiconFreeDecoder::decodeStep(const float* emissions, int T, int N) {
               &prevHyp,
               n,
               true, // prevBlank
-              prevHyp.amScore + amScore,
+              prevHyp.emittingModelScore + emittingModelScore,
               prevHyp.lmScore);
         } else {
           candidatesAdd(
@@ -105,7 +105,7 @@ void LexiconFreeDecoder::decodeStep(const float* emissions, int T, int N) {
               &prevHyp,
               n,
               false, // prevBlank
-              prevHyp.amScore + amScore,
+              prevHyp.emittingModelScore + emittingModelScore,
               prevHyp.lmScore);
         }
       }
@@ -142,7 +142,7 @@ void LexiconFreeDecoder::decodeEnd() {
         &prevHyp,
         sil_,
         false, // prevBlank
-        prevHyp.amScore,
+        prevHyp.emittingModelScore,
         prevHyp.lmScore + lmScore);
   }
 

--- a/flashlight/lib/text/decoder/LexiconFreeDecoder.h
+++ b/flashlight/lib/text/decoder/LexiconFreeDecoder.h
@@ -36,7 +36,7 @@ struct LexiconFreeDecoderState {
   int token; // Label of token
   bool prevBlank; // If previous hypothesis is blank (for CTC only)
 
-  double amScore; // Accumulated AM score so far
+  double emittingModelScore; // Accumulated AM score so far
   double lmScore; // Accumulated LM score so far
 
   LexiconFreeDecoderState(
@@ -45,14 +45,14 @@ struct LexiconFreeDecoderState {
       const LexiconFreeDecoderState* parent,
       const int token,
       const bool prevBlank = false,
-      const double amScore = 0,
+      const double emittingModelScore = 0,
       const double lmScore = 0)
       : score(score),
         lmState(lmState),
         parent(parent),
         token(token),
         prevBlank(prevBlank),
-        amScore(amScore),
+        emittingModelScore(emittingModelScore),
         lmScore(lmScore) {}
 
   LexiconFreeDecoderState()
@@ -61,7 +61,7 @@ struct LexiconFreeDecoderState {
         parent(nullptr),
         token(-1),
         prevBlank(false),
-        amScore(0.),
+        emittingModelScore(0.),
         lmScore(0.) {}
 
   int compareNoScoreStates(const LexiconFreeDecoderState* node) const {
@@ -92,7 +92,7 @@ struct LexiconFreeDecoderState {
  * AM(W) + lmWeight_ * log(P_{lm}(W)) + silScore_ * |{i| pi_i = <sil>}|
  *
  * where P_{lm}(W) is the language model score, pi_i is the value for the i-th
- * frame in the path leading to W and AM(W) is the (unnormalized) acoustic model
+ * frame in the path leading to W and AM(W) is the (unnormalized) emitting model
  * score of the transcription W. We are allowed to generate words from all the
  * possible combination of tokens.
  */


### PR DESCRIPTION
Summary: Rename speech-specific things (mostly `acoustic model`) to refer to an "emitting model" which might not be a speech-based model.

Differential Revision: D39797755

