### PR TITLE
Add Python wheel build automation

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,27 @@
+name: Build Python Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2022, macOS-12]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.10.1
+      - name: Build wheels
+        run: python -m cibuildwheel --archs auto64 --output-dir wheelhouse bindings/python
+        env:
+          CIBW_ENVIRONMENT: USE_KENLM=0
+          CIBW_BEFORE_BUILD: pip install packaging
+          CIBW_PRERELEASE_PYTHONS: 0
+          CIBW_BUILD_VERBOSITY: 1
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
### Summary
See title. `cibuidlwheel` setups for macOS, Linux, and Windows -- x64 only for now, pending access to PT self-hosted M1/Linux ARM runners.

Test plan: Watch Github actions and download fun artifacts, i.e. https://github.com/flashlight/text/actions
