### PR TITLE
Python bindings for seq2seq decoders

### DIFF
--- a/bindings/python/flashlight/lib/text/_decoder.cpp
+++ b/bindings/python/flashlight/lib/text/_decoder.cpp
@@ -5,11 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
 
 #include "flashlight/lib/text/decoder/LexiconDecoder.h"
 #include "flashlight/lib/text/decoder/LexiconFreeDecoder.h"
+#include "flashlight/lib/text/decoder/LexiconFreeSeq2SeqDecoder.h"
+#include "flashlight/lib/text/decoder/LexiconSeq2SeqDecoder.h"
+#include "flashlight/lib/text/decoder/Utils.h"
 #include "flashlight/lib/text/decoder/lm/ZeroLM.h"
 
 #if FL_TEXT_USE_KENLM
@@ -20,13 +25,8 @@ namespace py = pybind11;
 using namespace fl::lib::text;
 using namespace py::literals;
 
-/**
- * Some hackery that lets pybind11 handle shared_ptr<void> (for old LMStatePtr).
- * See: https://github.com/pybind/pybind11/issues/820
- * PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>);
- * and inside PYBIND11_MODULE
- *   py::class_<std::shared_ptr<void>>(m, "encapsulated_data");
- */
+PYBIND11_MAKE_OPAQUE(EmittingModelStatePtr);
+PYBIND11_MAKE_OPAQUE(std::vector<EmittingModelStatePtr>);
 
 namespace {
 
@@ -127,6 +127,43 @@ std::vector<DecodeResult> LexiconFreeDecoder_decode(
     int T,
     int N) {
   return decoder.decode(reinterpret_cast<const float*>(emissions), T, N);
+}
+
+void LexiconSeq2SeqDecoder_decodeStep(
+    LexiconSeq2SeqDecoder& decoder,
+    uintptr_t emissions,
+    int T,
+    int N) {
+  decoder.decodeStep(reinterpret_cast<const float*>(emissions), T, N);
+}
+
+void LexiconFreeSeq2SeqDecoder_decodeStep(
+    LexiconFreeSeq2SeqDecoder& decoder,
+    uintptr_t emissions,
+    int T,
+    int N) {
+  decoder.decodeStep(reinterpret_cast<const float*>(emissions), T, N);
+}
+
+/*
+ * Create an EmittingModelStatePtr from an arbitrary Python object. Since
+ * py::object refcounts Python and C++ usages (via its copy ctor), we can create
+ * a shared pointer straight away without worrying about lifetime.
+ */
+EmittingModelStatePtr createEmittingModelState(py::object obj) {
+  auto s = std::make_shared<py::object>(std::move(obj));
+  return std::static_pointer_cast<void>(s);
+}
+
+/*
+ * Recover a Python object from an EmittingModelStatePtr. Refcounting of
+ * py::object means we can return a copy.
+ */
+py::object getObjFromEmittingModelState(EmittingModelStatePtr state) {
+  // The only way to create this type from Python is via createModelStatePtr,
+  // which is guaranteed to store a py::object; this is a safe static cast.
+  auto val = std::static_pointer_cast<py::object>(state);
+  return *val;
 }
 
 } // namespace
@@ -411,4 +448,128 @@ PYBIND11_MODULE(flashlight_lib_text_decoder, m) {
                 t[3].cast<std::vector<float>>() // transitions
             );
           }));
+
+  // Seq2seq Decoding
+  py::class_<LexiconSeq2SeqDecoderOptions>(m, "LexiconSeq2SeqDecoderOptions")
+      .def(
+          py::init<
+              const int,
+              const int,
+              const double,
+              const double,
+              const double,
+              const double,
+              const bool>(),
+          "beam_size"_a,
+          "beam_size_token"_a,
+          "beam_threshold"_a,
+          "lm_weight"_a,
+          "word_score"_a,
+          "eos_score"_a,
+          "log_add"_a)
+      .def_readwrite("beam_size", &LexiconSeq2SeqDecoderOptions::beamSize)
+      .def_readwrite(
+          "beam_size_token", &LexiconSeq2SeqDecoderOptions::beamSizeToken)
+      .def_readwrite(
+          "beam_threshold", &LexiconSeq2SeqDecoderOptions::beamThreshold)
+      .def_readwrite("lm_weight", &LexiconSeq2SeqDecoderOptions::lmWeight)
+      .def_readwrite("word_score", &LexiconSeq2SeqDecoderOptions::wordScore)
+      .def_readwrite("eos_score", &LexiconSeq2SeqDecoderOptions::eosScore)
+      .def_readwrite("log_add", &LexiconSeq2SeqDecoderOptions::logAdd);
+
+  py::class_<LexiconFreeSeq2SeqDecoderOptions>(
+      m, "LexiconFreeSeq2SeqDecoderOptions")
+      .def(
+          py::init<
+              const int,
+              const int,
+              const double,
+              const double,
+              const double,
+              const bool>(),
+          "beam_size"_a,
+          "beam_size_token"_a,
+          "beam_threshold"_a,
+          "lm_weight"_a,
+          "eos_score"_a,
+          "log_add"_a)
+      .def_readwrite("beam_size", &LexiconFreeSeq2SeqDecoderOptions::beamSize)
+      .def_readwrite(
+          "beam_size_token", &LexiconFreeSeq2SeqDecoderOptions::beamSizeToken)
+      .def_readwrite(
+          "beam_threshold", &LexiconFreeSeq2SeqDecoderOptions::beamThreshold)
+      .def_readwrite("lm_weight", &LexiconFreeSeq2SeqDecoderOptions::lmWeight)
+      .def_readwrite("eos_score", &LexiconFreeSeq2SeqDecoderOptions::eosScore)
+      .def_readwrite("log_add", &LexiconFreeSeq2SeqDecoderOptions::logAdd);
+
+  py::class_<LexiconSeq2SeqDecoder>(m, "LexiconSeq2SeqDecoder")
+      .def(
+          py::init<
+              LexiconSeq2SeqDecoderOptions,
+              const TriePtr,
+              const LMPtr,
+              const int,
+              EmittingModelUpdateFunc,
+              const int,
+              const bool>(),
+          "options"_a,
+          "lm"_a,
+          "trie"_a,
+          "eos_idx"_a,
+          "update_func"_a,
+          "max_output_length"_a,
+          "is_token_lm"_a)
+      .def(
+          "decode_step",
+          &LexiconSeq2SeqDecoder_decodeStep,
+          "emissions"_a,
+          "T"_a,
+          "N"_a)
+      .def("prune", &LexiconSeq2SeqDecoder::prune, "look_back"_a = 0)
+      .def(
+          "get_best_hypothesis",
+          &LexiconSeq2SeqDecoder::getBestHypothesis,
+          "look_back"_a = 0)
+      .def(
+          "get_all_final_hypothesis",
+          &LexiconSeq2SeqDecoder::getAllFinalHypothesis);
+
+  // Constructor intentionally omitted -- not to be constructed directly.
+  // create_model_state and get_model_state_obj should be used to create
+  // instances of this type.
+  py::class_<EmittingModelStatePtr>(m, "EmittingModelState");
+  m.def("create_emitting_model_state", &createEmittingModelState);
+  m.def("get_obj_from_emitting_model_state", &getObjFromEmittingModelState);
+
+  py::bind_vector<std::vector<EmittingModelStatePtr>>(
+      m, "VectorEmittingModelState");
+  py::implicitly_convertible<py::list, std::vector<EmittingModelStatePtr>>();
+
+  py::class_<LexiconFreeSeq2SeqDecoder>(m, "LexiconFreeSeq2SeqDecoder")
+      .def(
+          py::init<
+              LexiconFreeSeq2SeqDecoderOptions,
+              const LMPtr,
+              const int,
+              EmittingModelUpdateFunc,
+              const int>(),
+          "options"_a,
+          "lm"_a,
+          "eos_idx"_a,
+          "update_func"_a,
+          "max_output_length"_a)
+      .def(
+          "decode_step",
+          &LexiconFreeSeq2SeqDecoder_decodeStep,
+          "emissions"_a,
+          "T"_a,
+          "N"_a)
+      .def("prune", &LexiconFreeSeq2SeqDecoder::prune, "look_back"_a = 0)
+      .def(
+          "get_best_hypothesis",
+          &LexiconFreeSeq2SeqDecoder::getBestHypothesis,
+          "look_back"_a = 0)
+      .def(
+          "get_all_final_hypothesis",
+          &LexiconFreeSeq2SeqDecoder::getAllFinalHypothesis);
 }

--- a/bindings/python/flashlight/lib/text/decoder.py
+++ b/bindings/python/flashlight/lib/text/decoder.py
@@ -9,12 +9,19 @@ LICENSE file in the root directory of this source tree.
 import logging
 
 from .flashlight_lib_text_decoder import (
+    create_emitting_model_state,
     CriterionType,
     DecodeResult,
+    EmittingModelState,
+    get_obj_from_emitting_model_state,
     LexiconDecoder,
     LexiconDecoderOptions,
     LexiconFreeDecoder,
     LexiconFreeDecoderOptions,
+    LexiconFreeSeq2SeqDecoder,
+    LexiconFreeSeq2SeqDecoderOptions,
+    LexiconSeq2SeqDecoder,
+    LexiconSeq2SeqDecoderOptions,
     LM,
     LMState,
     SmearingMode,


### PR DESCRIPTION
# Summary

Bind Seq2Seq/autoregressive beam search decoders from Flashlight Text to Python.

Two notable subtleties in how the bindings are structured to avoid overhead:
- `EmittingModelStatePtr` (a typedef'ed `std::shared_ptr<void>`) is exposed to Python interop via `std::shared_ptr<py::object>` (which itself is a reference counted wrapper around `PyObject*`.
  - `shared_ptr` will properly modify refcounts of the `py::object` such that there aren't lifetime issues round-trip -- if Python garbage collects autoregressive model state, refcount will be > 0 if being used in the decoder.
  - `get_obj_from_emitting_model_state` and `create_emitting_model_state` can create this type from arbitrary Python objects with ~no overhead.
  - This approach also avoids intermediate copies given that the passed `py::object` refers to the same underlying memory/handle/is COW
- `EmittingModelUpdateFunc`, which is the autoregressive callback defined in Python but called in C++ to get incremental model token scores and model state. This closure is passed from Python --> C++ once at decoder construction; a function pointer's stored in C++ to the Python callable. Opaque types preclude copies of scores from args or return vals -- this will be more carefully investigated/improved over time.

Tests are self-documenting for now for the `LexiconFreeSeq2Seq` variant.

### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest matter
- [x] Code documented
