### PR TITLE
Add namespace_packages to setup.py

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -107,7 +107,8 @@ setup(
     author_email="oncall+fair_speech@xmail.facebook.com",
     description="Flashlight Text bindings for python",
     long_description="",
-    packages=["flashlight", "flashlight.lib", "flashlight.lib.text"],
+    namespace_packages=["flashlight", "flashlight.lib"],
+    packages=["flashlight.lib.text"],
     ext_modules=[
         CMakeExtension("flashlight.lib.text.decoder"),
         CMakeExtension("flashlight.lib.text.dictionary"),


### PR DESCRIPTION
See title. Prevents breakage when installing multiple `flashlight.lib` modules from different repos.

### Test Plan (required) Local test on a clean Ubuntu box with Python 3.10

```
git clone https://github.com/flashlight/flashlight.git
cd flashlight
wget https://gist.githubusercontent.com/jacobkahn/f345a94974838c89df6b07f77824fca5/raw/65c3ca05961a92a08fbe1e2629a9290774baf6fd/diff.out
git apply diff.out
USE_CUDA=0 USE_MKL=0 pip install -e bindings/python
python -c "import flashlight.lib.sequence" # succeeds
```
and
```
git clone https://github.com/flashlight/text && cd text
cd bindings/python
python3 setup.py install
python -c "import flashlight.lib.text" # succeeds
```
