### PR TITLE
Add kwargs to Decoder ctors for Python bindings

### DIFF
--- a/bindings/python/flashlight/lib/text/_decoder.cpp
+++ b/bindings/python/flashlight/lib/text/_decoder.cpp
@@ -247,15 +247,24 @@ PYBIND11_MODULE(flashlight_lib_text_decoder, m) {
 
   // NB: `decode` and `decodeStep` expect raw emissions pointers.
   py::class_<LexiconDecoder>(m, "LexiconDecoder")
-      .def(py::init<
-           LexiconDecoderOptions,
-           const TriePtr,
-           const LMPtr,
-           const int,
-           const int,
-           const int,
-           const std::vector<float>&,
-           const bool>())
+      .def(
+          py::init<
+              LexiconDecoderOptions,
+              const TriePtr,
+              const LMPtr,
+              const int,
+              const int,
+              const int,
+              const std::vector<float>&,
+              const bool>(),
+          "options"_a,
+          "trie"_a,
+          "lm"_a,
+          "sil_token_idx"_a,
+          "blank_token_idx"_a,
+          "unk_token_idx"_a,
+          "transitions"_a,
+          "is_token_lm"_a)
       .def("decode_begin", &LexiconDecoder::decodeBegin)
       .def(
           "decode_step",
@@ -273,12 +282,18 @@ PYBIND11_MODULE(flashlight_lib_text_decoder, m) {
       .def("get_all_final_hypothesis", &LexiconDecoder::getAllFinalHypothesis);
 
   py::class_<LexiconFreeDecoder>(m, "LexiconFreeDecoder")
-      .def(py::init<
-           LexiconFreeDecoderOptions,
-           const LMPtr,
-           const int,
-           const int,
-           const std::vector<float>&>())
+      .def(
+          py::init<
+              LexiconFreeDecoderOptions,
+              const LMPtr,
+              const int,
+              const int,
+              const std::vector<float>&>(),
+          "options"_a,
+          "lm"_a,
+          "sil_token_idx"_a,
+          "blank_token_idx"_a,
+          "transitions"_a)
       .def("decode_begin", &LexiconFreeDecoder::decodeBegin)
       .def(
           "decode_step",

--- a/bindings/python/test/test_decoder.py
+++ b/bindings/python/test/test_decoder.py
@@ -189,15 +189,30 @@ class DecoderTestCase(unittest.TestCase):
         #                 word_score, unk_score, sil_score,
         #                 log_add, criterion_type (ASG or CTC))
         opts = LexiconDecoderOptions(
-            2500, 25000, 100.0, 2.0, 2.0, -math.inf, -1, False, CriterionType.ASG
+            beam_size=2500,
+            beam_size_token=25000,
+            beam_threshold=100.0,
+            lm_weight=2.0,
+            word_score=2.0,
+            unk_score=-math.inf,
+            sil_score=-1,
+            log_add=False,
+            criterion_type=CriterionType.ASG,
         )
 
         # define lexicon beam-search decoder with word-level lm
         # LexiconDecoder(decoder options, trie, lm, silence index,
         #                blank index (for CTC), unk index,
-        #                transitiona matrix, is token-level lm)
+        #                transitions matrix, is token-level lm)
         decoder = LexiconDecoder(
-            opts, trie, lm, separator_idx, -1, unk_idx, transitions, False
+            options=opts,
+            trie=trie,
+            lm=lm,
+            sil_token_idx=separator_idx,
+            blank_token_idx=-1,
+            unk_token_idx=unk_idx,
+            transitions=transitions,
+            is_token_lm=False,
         )
         # run decoding
         # decoder.decode(emissions, Time, Ntokens)


### PR DESCRIPTION
### Summary
See title. These were missing/the arg list are varied and long and was hard to keep track of.

This change doesn't affect argument orders/is fully backwards-compatible

### Test Plan:
`pip install -e bindings/python` then
`python bindings/python/test/test_decoder.py` which uses the kwargs for `LexiconDecoder`.

### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest matter
- [x] Code documented
