### PR TITLE
Fix python namespace packaging + Flashlight pkgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
             pip3 install packaging && \
             pip3 install numpy && \
             cd bindings/python && \
-            USE_KENLM=<< parameters.use_kenlm >> pip3 install -e .
+            USE_KENLM=<< parameters.use_kenlm >> python3 setup.py install
   run_python_tests:
     parameters:
       use_kenlm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
           name: "Install Build Dependencies"
           command: |
             sudo apt -y update && \
-            sudo apt -y install build-essential python3-dev python3-pip cmake
+            sudo apt -y install build-essential python3-dev python3-pip python3-venv cmake
       - when:
           condition:
             equal: ["ON", << parameters.use_kenlm >>]
@@ -118,12 +118,17 @@ commands:
         default: "ON"
     steps:
       - run:
+          name: "Setup virtualenv"
+          command: |
+            python3 -m venv venv
+            echo "source venv/bin/activate" >> $BASH_ENV
+      - run:
           name: "Install Python Bindings"
           command: |
-            pip3 install packaging && \
-            pip3 install numpy && \
+            pip install packaging && \
+            pip install numpy && \
             cd bindings/python && \
-            USE_KENLM=<< parameters.use_kenlm >> python3 setup.py install
+            USE_KENLM=<< parameters.use_kenlm >> python setup.py install
   run_python_tests:
     parameters:
       use_kenlm:
@@ -133,8 +138,8 @@ commands:
       - run:
           name: "Run Python Binding Tests"
           command: |
-            cd bindings/python/test && USE_KENLM=<< parameters.use_kenlm >> \
-            python3 -m unittest discover -v .
+            cd bindings/python/test && \
+            USE_KENLM=<< parameters.use_kenlm >> python -m unittest discover -v .
   test_with_external_project:
     parameters:
       build_shared_libs:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ wheels/
 
 # Compiled Dynamic libraries
 *.so
+*.so.*
 *.dylib
 *.dll
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Flashlight Text has Python bindings for decoder and Dictionary components. To in
 ```shell
 git clone https://github.com/flashlight/text && cd text
 cd bindings/python
-python3 setup.py install
+python setup.py install
 ```
 To install without KenLM, set the environment variable `USE_KENLM=0` when running `setup.py`.
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -22,12 +22,12 @@ We require `python >= 3.6` with the following packages installed:
 Once the dependencies are satisfied, from the project root, use:
 ```
 cd bindings/python
-python3 setup.py install
+python setup.py install
 ```
 
 or locally in editable mode (`-e` is required as libs are built outside of the bindings directory)
 ```
-pip3 install -e .
+pip install -e .
 ```
 
 (`pypi` installation coming soon)

--- a/bindings/python/flashlight/lib/text/__init__.py
+++ b/bindings/python/flashlight/lib/text/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+name = 'text'

--- a/bindings/python/flashlight/lib/text/__init__.py
+++ b/bindings/python/flashlight/lib/text/__init__.py
@@ -6,4 +6,4 @@ This source code is licensed under the MIT-style license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-name = 'text'
+name = "text"

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -107,7 +107,6 @@ setup(
     author_email="oncall+fair_speech@xmail.facebook.com",
     description="Flashlight Text bindings for python",
     long_description="",
-    namespace_packages=["flashlight", "flashlight.lib"],
     packages=["flashlight.lib.text"],
     ext_modules=[
         CMakeExtension("flashlight.lib.text.decoder"),


### PR DESCRIPTION
See title. Stop using `namespace_packages` since it's deprecated, and follow the official docs which stipulate removing `__init__.py` from every namespace dir that doesn't actually have package assets.

Test plan: tested install combos, i.e.
text:
```
conda create -n flashlight-python python=3.10
conda activate flashlight-python
cd text/bindings/python
USE_KENLM=0 python setup.py install
```
sequence:
```
cd sequence/bindings/python
USE_CUDA=0 python setup.py install
```
then test incremental install
```
python
> from flashlight.lib.text import decoder
> from flashlight.lib.sequence import criterion
```
then remove things:
```
pip uninstall flashlight-text
python
> from flashlight.lib.sequence import criterion
```
remove everything
```
pip uninstall flashlight-sequence
python
> import flashlight
>> ModuleNotFoundError: No module named 'flashlight'
```
### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest matter
- [x] Code documented
