### PR TITLE
Use pip install rather than setup.py cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@
 Flashlight Text has Python bindings for decoder and Dictionary components. To install the bindings from source, [install KenLM](https://github.com/kpu/kenlm/), then clone the repo and build:
 ```shell
 git clone https://github.com/flashlight/text && cd text
-cd bindings/python
-python setup.py install
+pip install .
 ```
-To install without KenLM, set the environment variable `USE_KENLM=0` when running `setup.py`.
+To install without KenLM, set the environment variable `USE_KENLM=0` when running `pip install [...]`.
 
 See the [full Python binding documentation](bindings/python) for examples and more.
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -20,11 +20,12 @@ We require `python >= 3.6` with the following packages installed:
 
 Once the dependencies are satisfied, from the project root, use:
 ```
-cd bindings/python
-python setup.py install
+pip install .
 ```
 
-or locally in editable mode (`-e` is required as libs are built outside of the bindings directory)
+Using the environment variable `USE_KENLM=0` removes the KenLM dependency but precludes using the decoder with a language model unless you write C++/`pybind11` bindings for your own language model.
+
+Install in editable mode for development:
 ```
 pip install -e .
 ```
@@ -32,9 +33,6 @@ pip install -e .
 (`pypi` installation coming soon)
 
 **Note:** if you encounter errors, you'll probably have to `rm -rf build dist` before retrying the install.
-
-### Advanced Options
-- `USE_KENLM=0` removes the KenLM dependency but precludes using the decoder unless you write C++/`pybind11` bindings for your own language model.
 
 ## Python API Documentation
 

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,9 @@ if __name__ == "__main__":
         author="Jacob Kahn",
         author_email="jacobkahn1@gmail.com",
         description="Flashlight Text bindings for Python",
+        long_description="Text utilities, including high performance beam "
+        + "search decoding, tokenization, and more",
+        long_description_content_type="text/markdown",
         packages=find_namespace_packages(
             where=PACKAGE_DIR, include=["flashlight.lib.text"], exclude=["test"]
         ),


### PR DESCRIPTION
### Summary
See title. Don't recommend `python setup.py install` -- recommend building wheels via `pip install [bindings dir]`.

Test plan: CI, local test