### PR TITLE
[packaging] Remove packaging as a build dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,6 @@ commands:
       - run:
           name: "Install Python Bindings"
           command: |
-            pip install packaging && \
             pip install numpy && \
             cd bindings/python && \
             USE_KENLM=<< parameters.use_kenlm >> python setup.py install

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,6 @@ jobs:
         run: python -m cibuildwheel --archs auto64 --output-dir wheelhouse bindings/python
         env:
           CIBW_ENVIRONMENT: USE_KENLM=0
-          CIBW_BEFORE_BUILD: pip install packaging
           CIBW_PRERELEASE_PYTHONS: 0
           CIBW_BUILD_VERBOSITY: 1
       - uses: actions/upload-artifact@v3

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -13,8 +13,7 @@ Define your own language model for beam search decoding
 ## Installation
 ### Dependencies
 We require `python >= 3.6` with the following packages installed:
-- [packaging](https://pypi.org/project/packaging/)
-- [cmake](https://cmake.org/) >= 3.10, and `make`
+- [cmake](https://cmake.org/) >= 3.16, and `make`
 - [KenLM](https://github.com/kpu/kenlm)
 
 ### Build Instructions

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-from packaging import version
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
@@ -46,8 +45,11 @@ class CMakeBuild(build_ext):
             )
 
         cmake_version = re.search(r"version\s*([\d.]+)", out.decode().lower()).group(1)
-        if version.parse(cmake_version) < version.parse("3.10"):
-            raise RuntimeError("CMake >= 3.10 is required to build flashlight-text")
+        cmake_version_tuple = tuple([int(v) for v in cmake_version.split(".")])
+        if cmake_version_tuple < (3, 16):
+            raise RuntimeError(
+                f"CMake >= 3.16 is required to build flashlight-text; found {cmake_version}"
+            )
 
         # our CMakeLists builds all the extensions at once
         for ext in self.extensions:


### PR DESCRIPTION
See title - removing the `packaging` package as a build time dependency and instead use tuple comparison operators to compare versions. Also bump the CMake minimum for Python install correctly to 3.16 minumum.

### Test Plan (required)
Local `python setup.py install` with and without CMake >= 3.16, + cibuildwheel

### Checklist

- [x] Test coverage
- [ ] Tests pass
- [ ] Code formatted
- [ ] Rebased on latest matter
