### PR TITLE
[packaging] Move and improve MANIFEST.in for wheel prep

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include CMakeLists.txt
+recursive-include cmake *.cmake *.cmake.in
+recursive-include flashlight/lib *.h *.cpp CMakeLists.txt
+recursive-include bindings/python *.cpp CMakeLists.txt
+global-exclude *.o *.so *.dylib *.a .git *.pyc *.swp

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,3 +1,0 @@
-include ../../CMakeLists.txt ../../cmake/* CMakeLists.txt
-recursive-include ../../flashlight/lib *.h *.cpp CMakeLists.txt
-recursive-include flashlight *.cpp


### PR DESCRIPTION
Move `MANIFEST.in` to project root and change paths to be relative to root + exclude extraneous filetypes.

### Test Plan (required)
CI + cibuildwheel
