### PR TITLE
Fix flaking LexiconFreeSeq2SeqDecoderTest

### DIFF
--- a/bindings/python/test/test_decoder.py
+++ b/bindings/python/test/test_decoder.py
@@ -332,7 +332,7 @@ class DecoderLexiconFreeSeq2SeqTestCase(unittest.TestCase):
         # timestep --> autoregressive scores
         self.model_score_mapping = {
             0: [0.1, 0.1, 0.5, 0.1],
-            1: [0.5, 0.2, 0.2, 0.1],
+            1: [0.5, 0.2, 0.1, 0.0],
             2: [0.1, 0.5, 0.1, 0.1],
         }
         self.assertEqual(len(self.model_score_mapping), T)

--- a/flashlight/lib/text/test/decoder/Seq2SeqDecoderTest.cpp
+++ b/flashlight/lib/text/test/decoder/Seq2SeqDecoderTest.cpp
@@ -53,7 +53,7 @@ TEST(Seq2SeqDecoderTest, LexiconFreeBasic) {
   // previous timestep) for the purposes of testing
   std::unordered_map<int, std::vector<float>> modelScoreMapping = {
       {0, {0.1, 0.1, 0.5, 0.1}},
-      {1, {0.5, 0.2, 0.2, 0.1}},
+      {1, {0.5, 0.2, 0.1, 0.0}},
       {2, {0.1, 0.5, 0.1, 0.1}},
   };
   ASSERT_EQ(modelScoreMapping.size(), T);


### PR DESCRIPTION
### Summary
Because multiple paths had identical scores for token idx 1 in the test, different compiler implementations of `std::sort` return different results ([thanks, MSVC](https://app.circleci.com/pipelines/github/flashlight/text/226/workflows/c525df27-b2a2-4e12-a8f9-5b5e639b663c/jobs/1895)!).

Test plan: CI/rebase Windows tests

### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest matter
- [x] Code documented
