### PR TITLE
Add previous hyp index to beam state and pass it in update func closure

### DIFF
--- a/bindings/python/test/test_decoder.py
+++ b/bindings/python/test/test_decoder.py
@@ -278,6 +278,7 @@ class DecoderLexiconFreeSeq2SeqTestCase(unittest.TestCase):
         N,
         T,
         prev_step_token_idxs,
+        prev_step_beam_idxs,
         prev_step_model_states,
         timestep,
     ):
@@ -292,6 +293,7 @@ class DecoderLexiconFreeSeq2SeqTestCase(unittest.TestCase):
         self.assertEqual(len(prev_step_token_idxs), len(prev_step_model_states))
         if timestep == 0:
             self.assertEqual(prev_step_token_idxs, [-1])
+            self.assertEqual(prev_step_beam_idxs, [-1])
             # This obj is actually a nullptr internally -- do not use
             self.assertEqual(len(prev_step_model_states), 1)
         else:
@@ -300,13 +302,18 @@ class DecoderLexiconFreeSeq2SeqTestCase(unittest.TestCase):
                 if timestep == 1:
                     self.assertEqual(prev_state.score, -1)
                     self.assertEqual(prev_state.token_idx, 0)
+                    self.assertEqual(
+                        prev_step_beam_idxs, [0] * len(prev_step_token_idxs)
+                    )
                 else:
                     self.assertGreater(timestep, 1)
                     scores = self.model_score_mapping[timestep - 1]
                     max_score = max(scores)
                     self.assertAlmostEqual(prev_state.score, max_score)
                     self.assertEqual(prev_state.token_idx, scores.index(max_score))
-
+                    self.assertEqual(
+                        prev_step_beam_idxs, [0] * len(prev_step_token_idxs)
+                    )
         cur_model_score = self.model_score_mapping[timestep]
 
         model_states = []

--- a/flashlight/lib/text/decoder/LexiconSeq2SeqDecoder.cpp
+++ b/flashlight/lib/text/decoder/LexiconSeq2SeqDecoder.cpp
@@ -39,13 +39,16 @@ void LexiconSeq2SeqDecoder::decodeStep(const float* emissions, int T, int N) {
 
     // Batch forwarding
     rawY_.clear();
+    rawBeamIdx_.clear();
     rawPrevStates_.clear();
+
     for (const LexiconSeq2SeqDecoderState& prevHyp : hyp_[t]) {
       const EmittingModelStatePtr& prevState = prevHyp.emittingModelState;
       if (prevHyp.token == eos_) {
         continue;
       }
       rawY_.push_back(prevHyp.token);
+      rawBeamIdx_.push_back(prevHyp.prevHypIdx.value_or(-1));
       rawPrevStates_.push_back(prevState);
     }
     if (rawY_.size() == 0) {
@@ -55,8 +58,8 @@ void LexiconSeq2SeqDecoder::decodeStep(const float* emissions, int T, int N) {
     std::vector<std::vector<float>> emittingModelScores;
     std::vector<EmittingModelStatePtr> outStates;
 
-    std::tie(emittingModelScores, outStates) =
-        emittingModelUpdateFunc_(emissions, N, T, rawY_, rawPrevStates_, t);
+    std::tie(emittingModelScores, outStates) = emittingModelUpdateFunc_(
+        emissions, N, T, rawY_, rawBeamIdx_, rawPrevStates_, t);
 
     std::vector<size_t> idx(emittingModelScores.back().size());
 

--- a/flashlight/lib/text/decoder/Utils.h
+++ b/flashlight/lib/text/decoder/Utils.h
@@ -101,6 +101,8 @@ using EmittingModelUpdateFunc = std::function<
      const std::vector<int>&, // The raw token ID of the last step for each
                               // element in the beam; the vector has as many
                               // elements as there are candidates in the beam.
+     const std::vector<int>&, // The indices of the beam hypotheses for which
+                              // the token ID at this index is being proposed.
      const std::vector<EmittingModelStatePtr>&, // State from the previous type
                                                 // steps for each candidate in
                                                 // the beam. Each hypothesis in


### PR DESCRIPTION
Add the previous hypothesis index for which a new token hypothesis is made to the seq2seq decoder state, and pass a collection of those indices in the update func closure to better facilitate caching and batching.

Test plan: CI, tests added

### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest matter
- [x] Code documented
