### PR TITLE
Ensure CMake uses the correct executable per cibuildwheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ class CMakeBuild(build_ext):
         )
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + ext_dir,
-            "-DPYTHON3_EXECUTABLE=" + sys.executable,
+            "-DPython3_EXECUTABLE=" + sys.executable,
             "-DBUILD_SHARED_LIBS=ON",
             "-DFL_TEXT_BUILD_STANDALONE=OFF",
             "-DFL_TEXT_BUILD_TESTS=OFF",

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ class CMakeBuild(build_ext):
         )
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + ext_dir,
-            "-DPYTHON_EXECUTABLE=" + sys.executable,
+            "-DPYTHON3_EXECUTABLE=" + sys.executable,
             "-DBUILD_SHARED_LIBS=ON",
             "-DFL_TEXT_BUILD_STANDALONE=OFF",
             "-DFL_TEXT_BUILD_TESTS=OFF",


### PR DESCRIPTION
See title. Using `FindPython3` in CMake >= 3.16 requires using `PYTHON3_EXECUTABLE` as the relevant flag specifying the interpreter path. This ensures that headers and modules are found in the proper subtree by CMake such that bindings are linked against the correct version of Python. Current Wheel builds link against totally spurious versions.

Test plan: CI + CIBW, ensuring that the correct CIBW version of Python is what CMake finds at wheel build time.