### PR TITLE
Remove superfluous add_subdirectory from Buildpybind11

### DIFF
--- a/cmake/Buildpybind11.cmake
+++ b/cmake/Buildpybind11.cmake
@@ -12,4 +12,3 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(pybind11)
-add_subdirectory(${pybind11_SOURCE_DIR})


### PR DESCRIPTION
Summary: CMake `FetchContent_MakeAvailable` already adds the target project's source and binary dirs and makes those targets available to the rest of the build -- this line as it stands does nothing and is just error prone

Differential Revision: D43447919

