### PR TITLE
Always find Threads in downstream projects, even w/o standalone

### DIFF
--- a/cmake/flashlight-text-config.cmake.in
+++ b/cmake/flashlight-text-config.cmake.in
@@ -20,12 +20,12 @@
 #
 
 # Dependencies
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
 # If not building standalone, don't try to find upstream deps,
 # as many of these find modules won't exist
 if (@FL_TEXT_BUILD_STANDALONE@)
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-  include(CMakeFindDependencyMacro)
-  find_dependency(Threads)
   if (@FL_TEXT_USE_KENLM@)
     find_dependency(kenlm)
   endif()


### PR DESCRIPTION
### Summary
Even though the CMake `Threads::Threads` target is linked to `flashlight-text` via private link visibility (such that downstream targets can't see the required target dep, it still creates a `LINK_ONLY` genexp in the generated `flashlight-text-targets` config, which means that `Threads` is required.

This is always required in any build, standalone or not, so make the `find_dependency` call in `flashlight-text-config` agnostic to whether or not `FL_TEXT_BUILD_STANDALONE` is enabled.

This was discovered whe using a Linux arm64 machine runner (with more comprehensive CircleCI matrices) which wasn't configured to have libpthread along its `LD_LIBRARY_PATH` for whatever reason, and required explicit linkage. Either way, the `Threads::Threads` target is generated, and needs to be valid regardless of the setup.

### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest matter
- [x] Code documented


Test plan: CI on machine Linux arm64 runner, which revealed the problem + local test
