### PR TITLE
Fix KenLM CMake module installation/usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ commands:
           command: |
             mkdir build && \
             cmake -S . -B build \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DBUILD_SHARED_LIBS=<< parameters.build_shared_libs >> \
               -DFL_TEXT_USE_KENLM=<< parameters.use_kenlm >> \
               -DFL_TEXT_BUILD_STANDALONE=<< parameters.build_standalone >> \

--- a/cmake/flashlight-text-config.cmake.in
+++ b/cmake/flashlight-text-config.cmake.in
@@ -24,14 +24,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 if (@FL_TEXT_USE_KENLM@)
-  if (@_FL_TEXT_FIND_KENLM_USED_MODULE@)
-    # Findkenlm.cmake was required to locate KenLM at build time
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}) # Findkenlm.cmake
-    find_dependency(kenlm)
-    list(REMOVE_AT CMAKE_MODULE_PATH -1) # remove from module path
-  else()
-    find_dependency(kenlm) # use config
-  endif() # _FL_TEXT_FIND_KENLM_USED_MODULE
+  find_dependency(kenlm)
 endif() # FL_TEXT_USE_KENLM
 
 ################################################################################

--- a/cmake/flashlight-text-config.cmake.in
+++ b/cmake/flashlight-text-config.cmake.in
@@ -7,6 +7,7 @@
 # `IMPORTED` targets:
 #
 # ``flashlight::flashlight-text``
+# ``flashlight::flashlight-text-kenlm`` if installed with KenLM
 #   The flashlight-text library.
 #
 # The above targets can be linked with your build using ``target_link_library``.
@@ -22,16 +23,16 @@
 # Dependencies
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
-# If not building standalone, don't try to find upstream deps,
-# as many of these find modules won't exist
-if (@FL_TEXT_BUILD_STANDALONE@)
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-  if (@FL_TEXT_USE_KENLM@)
+if (@FL_TEXT_USE_KENLM@)
+  if (@_FL_TEXT_FIND_KENLM_USED_MODULE@)
+    # Findkenlm.cmake was required to locate KenLM at build time
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}) # Findkenlm.cmake
     find_dependency(kenlm)
-  endif()
-  # Remove this dir from module path
-  list(REMOVE_AT CMAKE_MODULE_PATH -1)
-endif() # FL_TEXT_BUILD_STANDALONE
+    list(REMOVE_AT CMAKE_MODULE_PATH -1) # remove from module path
+  else()
+    find_dependency(kenlm) # use config
+  endif() # _FL_TEXT_FIND_KENLM_USED_MODULE
+endif() # FL_TEXT_USE_KENLM
 
 ################################################################################
 

--- a/flashlight/lib/text/decoder/lm/CMakeLists.txt
+++ b/flashlight/lib/text/decoder/lm/CMakeLists.txt
@@ -14,27 +14,22 @@ target_sources(
 if (FL_TEXT_USE_KENLM)
   find_package(kenlm CONFIG)
   if (NOT TARGET kenlm::kenlm)
-    find_package(kenlm)
-    if (NOT kenlm_FOUND)
+    if (FL_TEXT_BUILD_PYTHON)
+      # ONLY for Python installation, try to use Findkenlm.cmake to locate
+      # KenLM libs (and headers) since libkenlm's in site-packages w/o a config
+      find_package(kenlm MODULE REQUIRED) # use Findkenlm.cmake
+    else()
+      # Not building Python bindings - download standalone or fail
       if (FL_TEXT_BUILD_STANDALONE)
         message(STATUS "KenLM not found - will download and build from source")
         include(${PROJECT_SOURCE_DIR}/cmake/BuildKenlm.cmake)
       else()
-        message(FATAL_ERROR "KenLM not found but FL_TEXT_USE_KENLM enabled. "
-          "Install KenLM or set the KENLM_ROOT environment variable.")
-      endif()
-    else()
-      set(_FL_TEXT_FIND_KENLM_USED_MODULE ON) # for flashlight-text-config.cmake
-      # [KenLM was found via Findkenlm.cmake]
-      # Install the module so downstream projects can find the lib
-      # assuming it wasn't found with an exported target config
-      # *and* KenLM wasn't fetched/built from source at build time
-      install(
-        FILES ${PROJECT_SOURCE_DIR}/cmake/Findkenlm.cmake
-        DESTINATION ${FL_INSTALL_CMAKE_DIR}
-      )
-    endif()
-  endif()
+        message(WARNING "KenLM not found but FL_TEXT_USE_KENLM enabled. "
+          "Install KenLM to continue.")
+        find_package(kenlm CONFIG REQUIRED) # find again to display full errors
+      endif() # FL_TEXT_BUILD_STANDALONE
+    endif() # FL_TEXT_BUILD_PYTHON
+  endif() # NOT TARGET kenlm::kenlm
 
   target_sources(
     flashlight-text-kenlm

--- a/flashlight/lib/text/decoder/lm/CMakeLists.txt
+++ b/flashlight/lib/text/decoder/lm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(FL_TEXT_KENLM_MAX_ORDER 6 CACHE STRING "Maximum ngram order for KenLM")
 
@@ -23,14 +23,16 @@ if (FL_TEXT_USE_KENLM)
         message(FATAL_ERROR "KenLM not found but FL_TEXT_USE_KENLM enabled. "
           "Install KenLM or set the KENLM_ROOT environment variable.")
       endif()
-    endif()
-    if (FL_TEXT_BUILD_STANDALONE)
+    else()
+      set(_FL_TEXT_FIND_KENLM_USED_MODULE ON) # for flashlight-text-config.cmake
+      # [KenLM was found via Findkenlm.cmake]
       # Install the module so downstream projects can find the lib
       # assuming it wasn't found with an exported target config
+      # *and* KenLM wasn't fetched/built from source at build time
       install(
         FILES ${PROJECT_SOURCE_DIR}/cmake/Findkenlm.cmake
         DESTINATION ${FL_INSTALL_CMAKE_DIR}
-        )
+      )
     endif()
   endif()
 


### PR DESCRIPTION
### Summary
~~Change how `Findkenlm.cmake` is installed -- only install if it it was required to find KenLM in the first place (i.e. the KenLM `CONFIG`) didn't exist.~~ Never install `Findkenlm.cmake`, since it relies on a deprecated install flow. Only use it if building Python bindings which require `libkenlm.so` (and the Windows implib) from site-packages.

This also changes the exported CMake config to only use the CMake config version when finding KenLM for downstream project linking.

### Checklist

- [x] Test coverage
- [x] Tests pass
- [x] Code formatted
- [x] Rebased on latest matter
- [x] Code documented

Test plan: CI, local tests