### PR TITLE
Fix typo in quickstart, improve badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install flashlight-text
 ```
 To enable optional KenLM support in Python with the decoder, KenLM must be installed via pip:
 ```bash
-pip install git+https://github.com.kpu/kenlm.git
+pip install git+https://github.com/kpu/kenlm.git
 ```
 
 See the [full Python binding documentation](bindings/python) for examples and more.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 | [**Python Documentation**](bindings/python)
 | [**Citing**](#citing)
 
-[![CircleCI](https://circleci.com/gh/flashlight/text.svg?style=shield)](https://app.circleci.com/pipelines/github/flashlight/text)
-[![Join the chat at https://gitter.im/flashlight-ml/community](https://img.shields.io/gitter/room/flashlight-ml/community)](https://gitter.im/flashlight-ml/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) ![PyPI](https://img.shields.io/pypi/v/flashlight-text?color=dark%20green) ![PyPI - Format](https://img.shields.io/pypi/format/flashlight-text) [![codecov](https://codecov.io/gh/flashlight/text/branch/main/graph/badge.svg?token=rBp4AilMc0)](https://codecov.io/gh/flashlight/text)
+[![CircleCI](https://circleci.com/gh/flashlight/text.svg?style=shield)](https://app.circleci.com/pipelines/github/flashlight/text) [![Join the chat at https://gitter.im/flashlight-ml/community](https://img.shields.io/gitter/room/flashlight-ml/community)](https://gitter.im/flashlight-ml/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![PyPI](https://img.shields.io/pypi/v/flashlight-text?color=dark%20green)](https://pypi.org/project/flashlight-text/) [![PyPI - Format](https://img.shields.io/pypi/format/flashlight-text)](https://pypi.org/project/flashlight-text/#files) [![codecov](https://codecov.io/gh/flashlight/text/branch/main/graph/badge.svg?token=rBp4AilMc0)](https://codecov.io/gh/flashlight/text) [![GitHub](https://img.shields.io/github/license/flashlight/text?color=light%20green)](https://github.com/flashlight/text/blob/main/LICENSE)
 
 *Flashlight Text* is a fast, minimal library for text-based operations. It features:
 - a high-performance, unopinionated [beam search decoder](flashlight/lib/text/decoder)


### PR DESCRIPTION
Fixes https://github.com/flashlight/text/issues/63, adds badge links and a license badge.

Test plan: visual inspection