### PR TITLE
Fixing URL in installation instructions

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -7,7 +7,7 @@ pip install flashlight-text
 ```
 To enable optional KenLM support in Python with the decoder, KenLM must be installed via pip:
 ```bash
-pip install git+https://github.com.kpu/kenlm.git
+pip install git+https://github.com/kpu/kenlm.git
 ```
 
 #### Contents


### PR DESCRIPTION
Just a tiny fix of the KenLM installation instructions 