### PR TITLE
Update CIBW in CircleCI to get arm wheels for Py>=311

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ commands:
       - run:
           name: Build wheels
           command: |
-            python -m pip install cibuildwheel==2.12.1
+            python -m pip install cibuildwheel==2.16.5
             python -m cibuildwheel --output-dir wheelhouse
           environment:
             CIBW_BEFORE_BUILD: pip install -v git+https://github.com/kpu/kenlm.git && pip install cmake


### PR DESCRIPTION
Didn't update CIBW for CircleCI, which means some arm64 wheels are missing for Python > 3.11 -- https://pypi.org/project/flashlight-text/#files

Test plan:
CI