### PR TITLE
Convert directory fbcode/deeplearning to use the Ruff Formatter

### DIFF
--- a/bindings/python/test/test_decoder.py
+++ b/bindings/python/test/test_decoder.py
@@ -6,7 +6,6 @@ This source code is licensed under the MIT-style license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-
 import math
 import os
 import pickle


### PR DESCRIPTION
Summary:
X-link: https://github.com/flashlight/flashlight/pull/1176

X-link: https://github.com/pytorch/FBGEMM/pull/3242

Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files
bypass-github-export-checks

Differential Revision: D63766623


